### PR TITLE
Removed autostart of xdebug

### DIFF
--- a/src/php/devcontainer-feature.json
+++ b/src/php/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "php",
     "id": "php",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Installs PHP in Debian/Ubuntu based dev containers",
     "documentationURL": "https://github.com/shyim/devcontainers-features/tree/main/src/php",
     "options": {

--- a/src/php/install.sh
+++ b/src/php/install.sh
@@ -76,7 +76,6 @@ if [[ "${MODULES[@]}" =~ "xdebug" ]]; then
 
     echo "" >> "${XDEBUG_INI}"
     echo "xdebug.mode = debug" >> "${XDEBUG_INI}"
-    echo "xdebug.start_with_request = yes" >> "${XDEBUG_INI}"
     echo "xdebug.client_port = 9003" >> "${XDEBUG_INI}"
 fi
 


### PR DESCRIPTION
On my previous PR i've copied the default settings for the xdebug configuration from [https://github.com/devcontainers/features](https://github.com/devcontainers/features). 

The configuration works, but will provide a lot of noise in the stdout if you do not have an xdebug listener enabled. In some cases (like PHPUnit tests) these noises are really distracting. The configuration in question is `xdebug.start_with_request`, which is now configured with `yes`.

The default configuration of [xdebug.start_with_request](https://xdebug.org/docs/all_settings#start_with_request) will take `trigger`, which is in my opinion a better option than the current value. 

So in this PR i've removed the configuration. 