### PR TITLE
Fix extensionsExtra handling in PHP feature

### DIFF
--- a/src/php/NOTES.md
+++ b/src/php/NOTES.md
@@ -27,7 +27,7 @@ If you want to enable additional php extensions, you can use the following:
     "features": {
         "ghcr.io/shyim/devcontainers-features/php:latest": {
             "version": "8.0",
-            "extensionsExtra": "xdebug redis"
+            "extensionsExtra": "xdebug,redis,mbstring"
         }
     }
 }

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -1,4 +1,3 @@
-
 # php (php)
 
 Installs PHP in Debian/Ubuntu based dev containers
@@ -49,7 +48,7 @@ If you want to enable additional php extensions, you can use the following:
     "features": {
         "ghcr.io/shyim/devcontainers-features/php:latest": {
             "version": "8.0",
-            "extensionsExtra": "xdebug redis"
+            "extensionsExtra": "xdebug,redis,mbstring"
         }
     }
 }

--- a/src/php/devcontainer-feature.json
+++ b/src/php/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "php",
     "id": "php",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Installs PHP in Debian/Ubuntu based dev containers",
     "documentationURL": "https://github.com/shyim/devcontainers-features/tree/main/src/php",
     "options": {

--- a/src/php/install.sh
+++ b/src/php/install.sh
@@ -10,12 +10,12 @@ if [[ "$DISABLEALLEXTENSIONS" == "true" ]]; then
 fi
 
 if [[ -n "$EXTENSIONSEXTRA" ]]; then
-    EXTENSIONS="$EXTENSIONS $EXTENSIONSEXTRA"
+    EXTENSIONS="$EXTENSIONS,$EXTENSIONSEXTRA"
 fi
 
-EXTENSIONS="cgi cli fpm phpdbg $EXTENSIONS"
+EXTENSIONS="cgi,cli,fpm,phpdbg,$EXTENSIONS"
 
-MODULES=($EXTENSIONS)
+MODULES=(${EXTENSIONS//,/ })
 
 OS=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
 VERSION_CODENAME=$(awk -F= '$1=="VERSION_CODENAME" { print $2 ;}' /etc/os-release)
@@ -78,4 +78,3 @@ if [[ "${MODULES[@]}" =~ "xdebug" ]]; then
     echo "xdebug.mode = debug" >> "${XDEBUG_INI}"
     echo "xdebug.client_port = 9003" >> "${XDEBUG_INI}"
 fi
-

--- a/test/php/install_php_version_83.sh
+++ b/test/php/install_php_version_83.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+# Optional: Import test library
+source dev-container-features-test-lib
+
+check "php-version-8-is-installed" bash -c "php --version | grep '8.3'"
+check "composer-version" composer --version
+
+# Report result
+reportResults

--- a/test/php/install_php_xdebug_redis.sh
+++ b/test/php/install_php_xdebug_redis.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+check "php -v" php -v
+check "php-fpm -v" php-fpm8.2 -v
+
+check "php-xdebug-extension" php -m | grep "xdebug"
+check "php-xdebug-config" php -i | grep "xdebug.mode" | grep " => debug"
+check "php-redis-extension" php -m | grep "redis"
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults

--- a/test/php/scenarios.json
+++ b/test/php/scenarios.json
@@ -7,11 +7,27 @@
             }
         }
     },
+    "install_php_version_83": {
+        "image": "ubuntu:latest",
+        "features": {
+            "php": {
+                "version": "8.3"
+            }
+        }
+    },
     "install_php_xdebug": {
         "image": "ubuntu:latest",
         "features": {
             "php": {
               "extensionsExtra": "xdebug"
+            }
+        }
+    },
+    "install_php_xdebug_redis": {
+        "image": "ubuntu:latest",
+        "features": {
+            "php": {
+              "extensionsExtra": "xdebug,redis"
             }
         }
     }


### PR DESCRIPTION
Fixes #15

Update `EXTENSIONSEXTRA` handling in `src/php/install.sh` to include all specified extensions.

* Modify `src/php/install.sh` to concatenate `EXTENSIONSEXTRA` variable with other extensions using a comma separator.
* Update `src/php/README.md` and `src/php/NOTES.md` to reflect the correct handling of the `extensionsExtra` option.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shyim/devcontainers-features/pull/16?shareId=5961c595-f632-4a6c-a125-6989de513009).